### PR TITLE
Remove emotes with regex chars

### DIFF
--- a/test/emotes.spec.js
+++ b/test/emotes.spec.js
@@ -77,3 +77,21 @@ test( 'title', t => {
 		t.is( parseEmotes( emoteMap, input ), expected )
 	)
 } );
+
+test( 'does not throw exception when given emote with regex chars', t => {
+	[
+		// Twitch emotes
+		':/', ':(', ':o', ':z', 'B)', ':\\', ';)', ';p', ':p', 'R)', 'o_O',
+		':D', '>(', '<3', '<3', 'R)', ':>', '<]', ':7', ':(', ':P', ';P',
+		':O', ':\\', ':|', ':s', ':D', 'o_O', '>(', ':)', 'B)', ';)', '#/',
+		// Testing others
+		'][\\^$.|?*+)(}{',
+
+	].forEach( ( v, i ) => {
+		const emoteInfo = n =>
+			( { [ 'unsafe-' + i ]: [ `${ n }-${ v.length + ( n - 1 ) }` ] } )
+
+		t.is( parseEmotes( emoteInfo( 5 ), `xxxx ${ v } xxxx` ), 'xxxx xxxx' )
+		t.is( parseEmotes( emoteInfo( 0 ), v ), '' )
+	} )
+} );

--- a/translate.js
+++ b/translate.js
@@ -15,10 +15,11 @@ function translateMessage( channel, userstate, message, app ) {
     if( hasBlacklistedWord( message ) ) return;
 
     // Parsing for emotes
-    let filteredMessage = message.replace( twitchUsernameRegex, '' ).replace( whitespaceRegex, ' ' )
+    let filteredMessage = message
     if( userstate.emotes ) {
       filteredMessage = parseEmotes( userstate.emotes, filteredMessage );
     }
+    filteredMessage = message.replace( twitchUsernameRegex, '' ).replace( whitespaceRegex, ' ' )
 
     if( !filteredMessage ) return;
 

--- a/translate.js
+++ b/translate.js
@@ -19,7 +19,10 @@ function translateMessage( channel, userstate, message, app ) {
     if( userstate.emotes ) {
       filteredMessage = parseEmotes( userstate.emotes, filteredMessage );
     }
-    filteredMessage = message.replace( twitchUsernameRegex, '' ).replace( whitespaceRegex, ' ' )
+    filteredMessage = filteredMessage
+      .replace( twitchUsernameRegex, '' )
+      .replace( whitespaceRegex, ' ' )
+      .trim()
 
     if( !filteredMessage ) return;
 


### PR DESCRIPTION
Adding escapes to any regex chars in emotes, to prevent exceptions and other problems
Bypasses regexing if entire string is marked as emote
Now also bounding twitch emote regexes by whitespace and start/end of string. To handle that some characters themselves are word boundaries